### PR TITLE
Fixing ASN1 library version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.18.4
 
 LABEL maintainer="Michael Oberdorf IT-Consulting <info@oberdorf-itc.de>"
-LABEL site.local.program.version="1.0.0"
+LABEL site.local.program.version="1.0.1"
 
 ENV TZ=Europe/Berlin \
     CONFIG_FILE=/app/etc/snmp2mqtt.json

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Container image: [DockerHub](https://hub.docker.com/repository/docker/oitc/snmp2
 
 # Supported tags and respective `Dockerfile` links
 
-* [`latest`, `1.0.0`](https://github.com/cybcon/docker.snmp2mqtt/blob/v1.0.0/Dockerfile)
+* [`latest`, `1.0.1`](https://github.com/cybcon/docker.snmp2mqtt/blob/v1.0.1/Dockerfile)
+* [`1.0.0`](https://github.com/cybcon/docker.snmp2mqtt/blob/v1.0.0/Dockerfile)
 
 # Summary
 The container image is based on Alpine Linux with python3 interpreter.

--- a/src/app/bin/snmp2mqtt.py
+++ b/src/app/bin/snmp2mqtt.py
@@ -18,7 +18,7 @@ import datetime
 import time
 from pysnmp.hlapi import *
 
-VERSION='1.0.0'
+VERSION='1.0.1'
 
 CONFIG_FILE='/app/etc/snmp2mqtt.json'
 if 'CONFIG_FILE' in os.environ:

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,6 @@
 paho-mqtt >= 1.6.1, < 2.*
 ply >= 3.11, < 4.*
-pyasn1 >= 0.4.8, < 1.*
+pyasn1==0.4.8
 pycryptodomex >= 3.18.0, < 4.*
 pysmi >= 0.3.4, < 1.*
 pysnmp >= 4.4.12, < 5.*


### PR DESCRIPTION
# Summary

# Bugfix
Fixxing Issue
```
TypeError: decodeMessageVersion.<locals>.<lambda>() takes 3 positional arguments but 4 were given
```
which was known: https://github.com/etingof/pysnmp/issues/440